### PR TITLE
Recover Funds + Minimum Payout in Scalar Market

### DIFF
--- a/contracts/KPIToken.sol
+++ b/contracts/KPIToken.sol
@@ -29,6 +29,7 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
     address public creator;
     bool public finalized;
     uint256 public collateralAmount;
+    uint256 public minPayoutAmount;
     uint256 public initialSupply;
     uint256 public finalKpiProgress;
     ScalarData public scalarData;
@@ -52,10 +53,11 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
         TokenData calldata _tokenData,
         ScalarData calldata _scalarData
     ) external override initializer {
-        if(
+        if (
             IERC20Upgradeable(_collateral.token).balanceOf(address(this)) <
-                _collateral.amount)
-            revert NotEnoughCollateralBalance();
+            _collateral.amount || _collateral.minPayoutAmount >
+            _collateral.amount
+        ) revert NotEnoughCollateralBalance();
 
         __ERC20_init(_tokenData.name, _tokenData.symbol);
         _mint(_creator, _tokenData.totalSupply);
@@ -66,6 +68,7 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
         creator = _creator;
         scalarData = _scalarData;
         collateralAmount = _collateral.amount;
+        minPayoutAmount = _collateral.minPayoutAmount;
 
         emit Initialized(
             _kpiId,
@@ -78,8 +81,8 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
     }
 
     function finalize() external override {
-        if(finalized) revert AlreadyFinalized();
-        if(!oracle.isFinalized(kpiId)) revert NonFinalizedOracle();
+        if (finalized) revert AlreadyFinalized();
+        if (!oracle.isFinalized(kpiId)) revert NonFinalizedOracle();
         uint256 _oracleResult = uint256(oracle.resultFor(kpiId));
         if (
             _oracleResult <= scalarData.lowerBound ||
@@ -87,10 +90,10 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
         ) {
             // kpi below the lower bound or invalid, transfer funds back to creator
             finalKpiProgress = 0;
-            collateralToken.safeTransfer(creator, collateralAmount);
+            collateralToken.safeTransfer(creator, collateralAmount - minPayoutAmount);
         } else {
-            uint256 _kpiFullRange =
-                scalarData.higherBound - scalarData.lowerBound;
+            uint256 _kpiFullRange = scalarData.higherBound -
+                scalarData.lowerBound;
             finalKpiProgress = _oracleResult >= scalarData.higherBound
                 ? _kpiFullRange
                 : _oracleResult - scalarData.lowerBound;
@@ -98,7 +101,7 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
             if (finalKpiProgress < _kpiFullRange) {
                 collateralToken.safeTransfer(
                     creator,
-                    (collateralAmount * (_kpiFullRange - finalKpiProgress)) /
+                    ((collateralAmount - minPayoutAmount) * (_kpiFullRange - finalKpiProgress)) /
                         _kpiFullRange
                 );
             }
@@ -108,20 +111,21 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
     }
 
     function redeem() external override {
-        if(!finalized) revert NotFinalized();
+        if (!finalized) revert NotFinalized();
         uint256 _kpiTokenBalance = balanceOf(msg.sender);
-        if(_kpiTokenBalance == 0) revert NoKpiTokenBalance();
-        if (finalKpiProgress == 0) {
-            _burn(msg.sender, _kpiTokenBalance);
-            emit Redeemed(_kpiTokenBalance, 0);
+        if (_kpiTokenBalance == 0) revert NoKpiTokenBalance();
+        _burn(msg.sender, _kpiTokenBalance);
+        uint256 _redeemableBaseAmount = (minPayoutAmount * _kpiTokenBalance ) / (initialSupply);
+        if (finalKpiProgress == 0) {          
+            if (_redeemableBaseAmount > 0){
+                collateralToken.safeTransfer(msg.sender, _redeemableBaseAmount);
+            }
+            emit Redeemed(_kpiTokenBalance, _redeemableBaseAmount);
             return;
         }
-        _burn(msg.sender, _kpiTokenBalance);
         uint256 _scalarRange = scalarData.higherBound - scalarData.lowerBound;
-        uint256 _redeemableAmount =
-            (collateralAmount * _kpiTokenBalance * finalKpiProgress) /
-                (initialSupply * _scalarRange);
-        collateralToken.safeTransfer(msg.sender, _redeemableAmount);
-        emit Redeemed(_kpiTokenBalance, _redeemableAmount);
+        uint256 _redeemableScalableAmount = ((collateralAmount - minPayoutAmount) * _kpiTokenBalance * finalKpiProgress) / (initialSupply * _scalarRange);
+        collateralToken.safeTransfer(msg.sender, _redeemableBaseAmount + _redeemableScalableAmount);
+        emit Redeemed(_kpiTokenBalance, _redeemableBaseAmount + _redeemableScalableAmount);
     }
 }

--- a/contracts/KPIToken.sol
+++ b/contracts/KPIToken.sol
@@ -11,6 +11,7 @@ error AlreadyFinalized();
 error NonFinalizedOracle();
 error NotFinalized();
 error NoKpiTokenBalance();
+error CollateralNotRecoverable();
 
 /**
  * @title KPIToken
@@ -127,5 +128,11 @@ contract KPIToken is Initializable, ERC20Upgradeable, IKPIToken {
         uint256 _redeemableScalableAmount = ((collateralAmount - minPayoutAmount) * _kpiTokenBalance * finalKpiProgress) / (initialSupply * _scalarRange);
         collateralToken.safeTransfer(msg.sender, _redeemableBaseAmount + _redeemableScalableAmount);
         emit Redeemed(_kpiTokenBalance, _redeemableBaseAmount + _redeemableScalableAmount);
+    }
+
+    function recoverFunds(IERC20Upgradeable token) public {
+        if(token == collateralToken) revert CollateralNotRecoverable();
+        uint256 erc20balance = token.balanceOf(address(this));
+        token.safeTransfer(creator, erc20balance);
     }
 }

--- a/contracts/KPITokensFactory.sol
+++ b/contracts/KPITokensFactory.sol
@@ -15,6 +15,7 @@ error InvalidRealityExpiry();
 error ZeroAddressRealityArbitrator();
 error ZeroAddressCollateralToken();
 error InvalidCollateralAmount();
+error MinimumCollateralAmountTooHigh();
 error InvalidTokenName();
 error InvalidTokenSymbol();
 error ZeroTotalSupply();
@@ -96,6 +97,7 @@ contract KPITokensFactory is Ownable {
         if(_realityConfig.arbitrator == address(0)) revert ZeroAddressRealityArbitrator();
         if(_collateral.token == address(0)) revert ZeroAddressCollateralToken();
         if(_collateral.amount == 0) revert InvalidCollateralAmount();
+        if(_collateral.minPayoutAmount > _collateral.amount) revert MinimumCollateralAmountTooHigh();
         if(bytes(_tokenData.name).length == 0) revert InvalidTokenName();
         if(bytes(_tokenData.symbol).length == 0) revert InvalidTokenSymbol();
         if(_tokenData.totalSupply == 0) revert ZeroTotalSupply();

--- a/contracts/interfaces/IKPIToken.sol
+++ b/contracts/interfaces/IKPIToken.sol
@@ -12,6 +12,7 @@ interface IKPIToken is IERC20Upgradeable {
     struct Collateral {
         address token;
         uint256 amount;
+        uint256 minPayoutAmount;
     }
 
     struct TokenData {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "deploy:rinkeby": "hardhat deploy --network rinkeby --fee 30 --reality-address 0x3D00D77ee771405628a4bA4913175EcC095538da --verify",
         "deploy:xdai": "hardhat deploy --network xdai --fee 30 --reality-address 0x79e32aE03fb27B07C89c0c568F80287C01ca2E57 --fee-receiver-address 0xe716ec63c5673b3a4732d22909b38d779fa47c3f",
         "create:rinkeby": "hardhat create-kpi-token --network rinkeby --factory-address 0x6752241ee8420cb61A6ae6B666bD5759BFAC6eb0 --arbitrator-address 0xcafa054b1b054581faf65adce667bf1c684b6ef0 --vote-timeout 120",
-        "create:xdai": "hardhat create-kpi-token --network xdai --factory-address 0xe82c4D8b993D613a28600B953e91A3A93Ae69Fd6 --arbitrator-address 0xFe14059344b74043Af518d12931600C0f52dF7c5 --vote-timeout 120",
+        "create:xdai": "hardhat create-kpi-token --network xdai --factory-address 0xe82c4D8b993D613a28600B953e91A3A93Ae69Fd6 --arbitrator-address 0xFe14059344b74043Af518d12931600C0f52dF7c5 --vote-timeout 86400",
         "get-create-kpi-token-calldata": "hardhat get-create-kpi-token-calldata"
     },
     "devDependencies": {

--- a/tasks/create-kpi-token.ts
+++ b/tasks/create-kpi-token.ts
@@ -8,6 +8,7 @@ interface TaskArguments {
     question: string;
     collateralAddress: string;
     collateralAmount: string;
+    minPayoutAmount: string;
     tokenName: string;
     tokenSymbol: string;
     lowerBound: string;
@@ -38,7 +39,10 @@ task("create-kpi-token", "Creates a KPI token")
     .addParam("tokenSymbol", "Token symbol")
     .addParam("lowerBound", "Scalar lower bound")
     .addParam("higherBound", "Scalar higher bound")
-    .addOptionalParam("expiry", "The expiry timestamp (seconds since UNIX epoch)")
+    .addOptionalParam(
+        "expiry",
+        "The expiry timestamp (seconds since UNIX epoch)"
+    )
     .setAction(
         async (
             {
@@ -46,6 +50,7 @@ task("create-kpi-token", "Creates a KPI token")
                 question,
                 collateralAddress,
                 collateralAmount,
+                minPayoutAmount,
                 tokenName,
                 tokenSymbol,
                 lowerBound,
@@ -59,7 +64,7 @@ task("create-kpi-token", "Creates a KPI token")
             await hre.run("clean");
             await hre.run("compile");
             const [signer] = await hre.ethers.getSigners();
-
+            /*
             const collateralErc20 = (
                 await hre.ethers.getContractFactory("ERC20")
             )
@@ -84,7 +89,7 @@ task("create-kpi-token", "Creates a KPI token")
                 await approveTx.wait();
                 console.log("collateral approved");
             }
-
+            */
             const factory = await (
                 await hre.ethers.getContractFactory("KPITokensFactory")
             )
@@ -94,24 +99,28 @@ task("create-kpi-token", "Creates a KPI token")
                 /^"|"$/g,
                 ""
             )}\u241fkpi\u241fen_US`;
+            console.log(question, "\n", encodedRealityQuestion);
             console.log("creating");
             const transaction = await factory.createKpiToken(
                 {
                     question: encodedRealityQuestion,
                     arbitrator: arbitratorAddress,
-                    expiry: expiry || Math.floor(
-                        DateTime.now().plus({ minutes: 2 }).toSeconds()
-                    ),
+                    expiry:
+                        expiry ||
+                        Math.floor(
+                            DateTime.now().plus({ minutes: 2 }).toSeconds()
+                        ),
                     timeout: voteTimeout,
                 },
                 {
                     token: collateralAddress,
-                    amount: baseAmount,
+                    amount: collateralAmount,
+                    minPayoutAmount: minPayoutAmount,
                 },
                 {
                     name: tokenName,
                     symbol: tokenSymbol,
-                    totalSupply: "100000000000000000000000", //100k
+                    totalSupply: "10000000000000000000000", //100k
                 },
                 { lowerBound, higherBound }
             );

--- a/tasks/get-create-kpi-token-calldata.ts
+++ b/tasks/get-create-kpi-token-calldata.ts
@@ -6,6 +6,7 @@ interface TaskArguments {
     question: string;
     collateralAddress: string;
     collateralAmount: string;
+    minPayoutAmount: string;
     tokenName: string;
     tokenSymbol: string;
     lowerBound: string;
@@ -34,6 +35,7 @@ task("get-create-kpi-token-calldata", "Gets create KPI token calldata")
                 question,
                 collateralAddress,
                 collateralAmount,
+                minPayoutAmount,
                 tokenName,
                 tokenSymbol,
                 lowerBound,
@@ -65,6 +67,7 @@ task("get-create-kpi-token-calldata", "Gets create KPI token calldata")
                     {
                         token: collateralAddress,
                         amount: collateralAmount,
+                        minPayoutAmount: minPayoutAmount,
                     },
                     {
                         name: tokenName,


### PR DESCRIPTION
In this PR:

- add the functionality that makes it possible to recover ERC20 tokens sent to the contract which aren't the collateral back to the creator.

- add ability to have a minimum payout amount for the KPI token in a scalar market. So that even if the lower bound is not met holders can still redeem a fraction of the collateral. 

 